### PR TITLE
Fix scala collection list compilation errors

### DIFF
--- a/plugin/spark3/common/src/main/java/spark/sql/catalog/ndb/NDBRowLevelOperationIdentifier.java
+++ b/plugin/spark3/common/src/main/java/spark/sql/catalog/ndb/NDBRowLevelOperationIdentifier.java
@@ -37,7 +37,7 @@ public final class NDBRowLevelOperationIdentifier
 
     public static Seq<String> adaptTableIdentifiersToRowLevelOp(Seq<String> origIdentifiers)
     {
-        Builder<String, List<String>> newIdentifiersBuilder = List.newBuilder();
+        Builder<String, List<String>> newIdentifiersBuilder = List$.MODULE$.newBuilder();
         IntStream.range(0, origIdentifiers.size() - 1).forEachOrdered(i -> newIdentifiersBuilder.$plus$eq(origIdentifiers.apply(i)));
         String adaptedTableName = adaptTableNameToRowLevelOp(origIdentifiers.apply(origIdentifiers.size() - 1));
         newIdentifiersBuilder.$plus$eq(adaptedTableName);

--- a/plugin/spark3/spark34/src/main/java/com/vastdata/spark/statistics/AnalyzeNDBColumnCommand.java
+++ b/plugin/spark3/spark34/src/main/java/com/vastdata/spark/statistics/AnalyzeNDBColumnCommand.java
@@ -89,7 +89,7 @@ public class AnalyzeNDBColumnCommand
         final SparkSession session = session();
         final LogicalPlan rel = session.table(relation.name()).logicalPlan();
         final Seq<Attribute> columns = rel.output();
-        Builder<Attribute, List<Attribute>> newOutputBuilder = List.newBuilder();
+        Builder<Attribute, List<Attribute>> newOutputBuilder = List$.MODULE$.newBuilder();
         IntStream.range(0, columns.size()).mapToObj(columns::apply).filter(ar -> { return columnNames.contains( ar.name()); }).forEach(newOutputBuilder::$plus$eq);
         List<Attribute> newColumns = newOutputBuilder.result();
 

--- a/plugin/spark3/spark34/src/main/java/ndb/NDBStrategy.java
+++ b/plugin/spark3/spark34/src/main/java/ndb/NDBStrategy.java
@@ -106,7 +106,7 @@ public class NDBStrategy extends SparkStrategy
 
     private scala.collection.immutable.Seq<SparkPlan> planToResultImmutableSeq(SparkPlan plan)
     {
-        Builder<SparkPlan, List<SparkPlan>> builder = List.newBuilder();
+        Builder<SparkPlan, List<SparkPlan>> builder = List$.MODULE$.newBuilder();
         builder.addOne(plan);
         return builder.result();
     }

--- a/plugin/spark3/spark34/src/main/java/ndb/view/DropNDBViewPlan.java
+++ b/plugin/spark3/spark34/src/main/java/ndb/view/DropNDBViewPlan.java
@@ -13,6 +13,7 @@ import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.Metadata;
 import scala.collection.immutable.IndexedSeq;
 import scala.collection.immutable.List;
+import scala.collection.immutable.List$;
 import scala.collection.immutable.Seq;
 import scala.collection.mutable.Builder;
 
@@ -23,7 +24,7 @@ public class DropNDBViewPlan
 {
     public static final Seq<Attribute> OUTPUT;
     static {
-        Builder<Attribute, List<Attribute>> b = List.newBuilder();
+        Builder<Attribute, List<Attribute>> b = List$.MODULE$.newBuilder();
         Attribute resAttr = new AttributeReference("dropped",
                 DataTypes.BooleanType, true, Metadata.empty(), ExprId.apply(0),
                 (scala.collection.immutable.Seq<String>) scala.collection.immutable.Seq$.MODULE$.<String>empty());

--- a/plugin/spark3/spark34/src/main/java/ndb/view/NDBViewsResolutionRule.java
+++ b/plugin/spark3/spark34/src/main/java/ndb/view/NDBViewsResolutionRule.java
@@ -128,7 +128,7 @@ public class NDBViewsResolutionRule
                 catch (Exception e) {
                     throw new RuntimeException(QueryCompilationErrors.invalidViewText(query, viewName));
                 }
-                Builder<String, List<String>> namespaceSeqBuilder = List.newBuilder();
+                Builder<String, List<String>> namespaceSeqBuilder = List$.MODULE$.newBuilder();
                 for (String part : vastView.currentNamespace()) {
                     namespaceSeqBuilder.addOne(part);
                 }
@@ -181,7 +181,7 @@ public class NDBViewsResolutionRule
                 }
                 else {
                     Table vastViewTable = vastView.asTable();
-                    Builder<Attribute, List<Attribute>> attributeListBuilder = List.newBuilder();
+                    Builder<Attribute, List<Attribute>> attributeListBuilder = List$.MODULE$.newBuilder();
                     for (StructField field : vastViewTable.schema().fields()) {
                         attributeListBuilder.addOne(field.toAttribute());
                     }

--- a/plugin/spark3/spark35/src/main/java/com/vastdata/spark/statistics/AnalyzeNDBColumnCommand.java
+++ b/plugin/spark3/spark35/src/main/java/com/vastdata/spark/statistics/AnalyzeNDBColumnCommand.java
@@ -91,7 +91,7 @@ public class AnalyzeNDBColumnCommand
         SparkSession session = session();
         LogicalPlan rel = session.table(relation.name()).logicalPlan();
         Seq<Attribute> columns = rel.output();
-        Builder<Attribute, List<Attribute>> newOutputBuilder = List.newBuilder();
+        Builder<Attribute, List<Attribute>> newOutputBuilder = List$.MODULE$.newBuilder();
         IntStream.range(0, columns.size()).mapToObj(columns::apply).filter(ar -> {
             if (!columnNames.contains( ar.name())) {
                 return false;

--- a/plugin/spark3/spark35/src/main/java/ndb/NDBRowLevelResolutionRule.java
+++ b/plugin/spark3/spark35/src/main/java/ndb/NDBRowLevelResolutionRule.java
@@ -72,7 +72,7 @@ public class NDBRowLevelResolutionRule
             Function1<LogicalPlan, LogicalPlan> func = lp -> {
                 if (lp instanceof DataSourceV2Relation) {
                     DataSourceV2Relation v2Relation = (DataSourceV2Relation) lp;
-                    Builder<AttributeReference, List<AttributeReference>> refsWithRowID = List.newBuilder();
+                    Builder<AttributeReference, List<AttributeReference>> refsWithRowID = List$.MODULE$.newBuilder();
                     AttributeReference rowIdAttRef = new AttributeReference(SPARK_ROW_ID_FIELD.name(), SPARK_ROW_ID_FIELD.dataType(), false, Metadata.empty(), ExprId.apply(0), List.<String>newBuilder().result());
                     v2Relation.output().foreach(refsWithRowID::$plus$eq);
                     refsWithRowID.$plus$eq(rowIdAttRef);

--- a/plugin/spark3/spark35/src/main/java/ndb/NDBStrategy.java
+++ b/plugin/spark3/spark35/src/main/java/ndb/NDBStrategy.java
@@ -92,7 +92,7 @@ public class NDBStrategy extends SparkStrategy
 
     private scala.collection.immutable.Seq<SparkPlan> planToResultImmutableSeq(SparkPlan plan)
     {
-        Builder<SparkPlan, List<SparkPlan>> builder = List.newBuilder();
+        Builder<SparkPlan, List<SparkPlan>> builder = List$.MODULE$.newBuilder();
         builder.addOne(plan);
         return builder.result();
     }

--- a/plugin/spark3/spark35/src/main/java/ndb/view/DropNDBViewPlan.java
+++ b/plugin/spark3/spark35/src/main/java/ndb/view/DropNDBViewPlan.java
@@ -13,6 +13,7 @@ import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.Metadata;
 import scala.collection.immutable.IndexedSeq;
 import scala.collection.immutable.List;
+import scala.collection.immutable.List$;
 import scala.collection.immutable.Seq;
 import scala.collection.mutable.Builder;
 
@@ -23,7 +24,7 @@ public class DropNDBViewPlan
 {
     public static final Seq<Attribute> OUTPUT;
     static {
-        Builder<Attribute, List<Attribute>> b = List.newBuilder();
+        Builder<Attribute, List<Attribute>> b = List$.MODULE$.newBuilder();
         Attribute resAttr = new AttributeReference("dropped",
                 DataTypes.BooleanType, true, Metadata.empty(), ExprId.apply(0),
                 (scala.collection.immutable.Seq<String>) scala.collection.immutable.Seq$.MODULE$.<String>empty());

--- a/plugin/spark3/spark35/src/main/java/ndb/view/NDBViewsResolutionRule.java
+++ b/plugin/spark3/spark35/src/main/java/ndb/view/NDBViewsResolutionRule.java
@@ -124,7 +124,7 @@ public class NDBViewsResolutionRule
                 catch (Exception e) {
                     throw new RuntimeException(QueryCompilationErrors.invalidViewText(query, viewName));
                 }
-                Builder<String, List<String>> namespaceSeqBuilder = List.newBuilder();
+                Builder<String, List<String>> namespaceSeqBuilder = List$.MODULE$.newBuilder();
                 for (String part : vastView.currentNamespace()) {
                     namespaceSeqBuilder.addOne(part);
                 }
@@ -177,7 +177,7 @@ public class NDBViewsResolutionRule
                 }
                 else {
                     Table vastViewTable = vastView.asTable();
-                    Builder<Attribute, List<Attribute>> attributeListBuilder = List.newBuilder();
+                    Builder<Attribute, List<Attribute>> attributeListBuilder = List$.MODULE$.newBuilder();
                     for (StructField field : vastViewTable.schema().fields()) {
                         attributeListBuilder.addOne(
                                 new AttributeReference(field.name(), field.dataType(), field.nullable(),

--- a/plugin/spark3/spark35/test/java/com/vastdata/spark/write/TestInternalRowsQFactory.java
+++ b/plugin/spark3/spark35/test/java/com/vastdata/spark/write/TestInternalRowsQFactory.java
@@ -21,21 +21,21 @@ public class TestInternalRowsQFactory
     public void testForUpdate()
     {
         Queue<InternalRow> unit = InternalRowsQFactory.forUpdate(10);
-        Builder<Object, List<Object>> valuesBuilder = List.newBuilder();
+        Builder<Object, List<Object>> valuesBuilder = List$.MODULE$.newBuilder();
         valuesBuilder.$plus$eq(1L);
         valuesBuilder.$plus$eq(UTF8String.fromString("aaa"));
         List<Object> values = valuesBuilder.result();
         InternalRow r1 = InternalRow$.MODULE$.apply(values);
         unit.add(r1);
         assertEquals(unit.peek(), r1);
-        valuesBuilder = List.newBuilder();
+        valuesBuilder = List$.MODULE$.newBuilder();
         valuesBuilder.$plus$eq(2L);
         valuesBuilder.$plus$eq(UTF8String.fromString("bbb"));
         values = valuesBuilder.result();
         InternalRow r2 = InternalRow$.MODULE$.apply(values);
         unit.add(r2);
         assertEquals(unit.peek(), r1);
-        valuesBuilder = List.newBuilder();
+        valuesBuilder = List$.MODULE$.newBuilder();
         valuesBuilder.$plus$eq(0L);
         valuesBuilder.$plus$eq(UTF8String.fromString("ccc"));
         values = valuesBuilder.result();


### PR DESCRIPTION
Update Scala collection builder calls to `List$.MODULE$.newBuilder()` to fix compilation errors in Scala 2.13 environments.

The `scala.collection.List.newBuilder()` method was removed in Scala 2.13. This change ensures compatibility by using `scala.collection.immutable.List$.MODULE$.newBuilder()` and adding the necessary `List$` imports.

---
<a href="https://cursor.com/background-agent?bcId=bc-5ff7e729-5a0a-41dc-b392-4a53738eb2d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5ff7e729-5a0a-41dc-b392-4a53738eb2d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

