### PR TITLE
Resolve scala seqops nosuchmethoderror

### DIFF
--- a/plugin/spark3/spark34/src/main/java/ndb/NDBParser.java
+++ b/plugin/spark3/spark34/src/main/java/ndb/NDBParser.java
@@ -28,6 +28,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import scala.Function1;
 import scala.PartialFunction;
+import scala.collection.immutable.List$;
 import scala.collection.immutable.Seq;
 import scala.collection.immutable.Seq$;
 
@@ -36,7 +37,7 @@ import static spark.sql.catalog.ndb.NDBRowLevelOperationIdentifier.adaptTableIde
 public class NDBParser implements ParserInterface {
     private static final Logger LOG = LoggerFactory.getLogger(NDBParser.class);
 
-    public static final Seq<LogicalPlan> EMPTY_LOGICAL_PLAN_SEQ = (Seq<LogicalPlan>) Seq$.MODULE$.<LogicalPlan>empty();
+    public static final Seq<LogicalPlan> EMPTY_LOGICAL_PLAN_SEQ = scala.collection.immutable.List$.MODULE$.<LogicalPlan>empty();
 
     private final SparkSession session;
     private final ParserInterface parser;

--- a/plugin/spark3/spark35/src/main/java/ndb/NDBParser.java
+++ b/plugin/spark3/spark35/src/main/java/ndb/NDBParser.java
@@ -30,6 +30,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import scala.Function1;
 import scala.PartialFunction;
+import scala.collection.immutable.List$;
 import scala.collection.immutable.Seq;
 import scala.collection.immutable.Seq$;
 
@@ -40,7 +41,7 @@ public class NDBParser
 {
     private static final Logger LOG = LoggerFactory.getLogger(NDBParser.class);
 
-    public static final Seq<LogicalPlan> EMPTY_LOGICAL_PLAN_SEQ = (Seq<LogicalPlan>) Seq$.MODULE$.<LogicalPlan>empty();
+    public static final Seq<LogicalPlan> EMPTY_LOGICAL_PLAN_SEQ = scala.collection.immutable.List$.MODULE$.<LogicalPlan>empty();
 
     private final SparkSession session;
     private final ParserInterface parser;


### PR DESCRIPTION
Fix `NoSuchMethodError` by updating `Seq.empty()` to `List.empty()` for Scala 2.13 compatibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-bb4c7a6e-d16c-4721-be26-01550874b860"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-bb4c7a6e-d16c-4721-be26-01550874b860"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

